### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ just-in-time code generators and other optimizations.
 #### What's the big deal about authorizations?
 
 Writing a complex application is hard-enough, add to this any significantly-complex
-authorization scheme and the whole thing breaks appart, slows-down to a crawl, clutters
+authorization scheme and the whole thing breaks apart, slows-down to a crawl, clutters
 the code with plenty of unspotted security holes throughout every part of the
 application, and every now and then exposes end-users' data to unauthorized users.
 


### PR DESCRIPTION
@ReactiveSets, I've corrected a typographical error in the documentation of the [toubkal](https://github.com/ReactiveSets/toubkal) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.