### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,7 +1016,7 @@ Other Classes && methods  | Short Description
 --------------------------|------------------------------------------------
 value_equals()            | Allows comparison of any types of values, including deeply nested objects and arrays
 undefine()                | Universal module loader for node and the browser, exported as own npm module
-Lap_Timer                 | Helps calulate time difference between events, used by loggers
+Lap_Timer                 | Helps calculate time difference between events, used by loggers
 Console_Logger            | Logger to console.log() with timestamps and lap lines 
 Client assets             | Sets to ease assembly of minified files for clients
 HTTP_Router               | Efficiently route HTTP requests using base URLs


### PR DESCRIPTION
@ReactiveSets, I've corrected a typographical error in the documentation of the [toubkal](https://github.com/ReactiveSets/toubkal) project. Specifically, I've changed calulate to calculate. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.